### PR TITLE
feat: introduce declarative function signatures

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ '7.2', '7.3', '7.4','8.0' ]
+        php-version: [ '7.4','8.0' ]
     name: PHP ${{ matrix.php-version }} Conformance Test
     steps:
     - name: Checkout code

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -47,11 +47,35 @@ jobs:
         useBuildpacks: false
         cmd: "'php -S localhost:8080 router.php'"
 
+    - name: Run Declarative HTTP conformance tests
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.2.0
+      env:
+        FUNCTION_TARGET: 'declarativeHttpFunc'
+        FUNCTION_SOURCE: ${{ github.workspace }}/tests/conformance/index.php
+      with:
+        version: 'v1.0.0'
+        functionType: 'http'
+        useBuildpacks: false
+        cmd: "'php -S localhost:8080 router.php'"
+
     - name: Run CloudEvent conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.2.0
       env:
         FUNCTION_TARGET: 'cloudEventFunc'
         FUNCTION_SIGNATURE_TYPE: 'cloudevent'
+        FUNCTION_SOURCE: ${{ github.workspace }}/tests/conformance/index.php
+      with:
+        version: 'v1.0.0'
+        functionType: 'cloudevent'
+        useBuildpacks: false
+        validateMapping: true
+        cmd: "'php -S localhost:8080 router.php'"
+
+
+    - name: Run Declarative CloudEvent conformance tests
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.2.0
+      env:
+        FUNCTION_TARGET: 'declarativeCloudEventFunc'
         FUNCTION_SOURCE: ${{ github.workspace }}/tests/conformance/index.php
       with:
         version: 'v1.0.0'

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: [ '7.2', '7.3', '7.4','8.0' ]
+        php-versions: [ '7.4','8.0' ]
     name: PHP ${{ matrix.php-versions }} Unit Test
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,10 @@
   "description": "Google Cloud Functions Framework for PHP",
   "license": "Apache-2.0",
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "guzzlehttp/psr7": "^1.7|^2.0",
-    "psr/http-message": "^1.0"
+    "psr/http-message": "^1.0",
+    "cloudevents/sdk-php": "^1.0"
   },
   "suggest": {
     "google/cloud-storage": "Google Cloud Storage client library for storing and persisting objects. When included, the functions framework will register the gs:// stream wrapper."
@@ -16,7 +17,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0|^8.0",
+    "phpunit/phpunit": "^7.5|^8.0",
     "guzzlehttp/guzzle": "^7.2"
   },
   "bin": [

--- a/router.php
+++ b/router.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2019 Google LLC.
  *
@@ -49,16 +50,8 @@ $projectContext->registerCloudStorageStreamWrapperIfPossible();
     if (false === $target) {
         throw new RuntimeException('FUNCTION_TARGET is not set');
     }
-    if (!is_callable($target)) {
-        throw new InvalidArgumentException(sprintf(
-            'Function target is not callable: "%s"',
-            $target
-        ));
-    }
 
-    $signatureType = getenv('FUNCTION_SIGNATURE_TYPE', true) ?: 'http';
-
-    $invoker = new Invoker($target, $signatureType);
+    $invoker = new Invoker($target);
     $response = $invoker->handle();
     (new Emitter())->emit($response);
 })();

--- a/run_conformance_tests.sh
+++ b/run_conformance_tests.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Runs the conformance tests locally from https://github.com/GoogleCloudPlatform/functions-framework-conformance.
+# Requires Go 1.16+ to run.
+#
+# Servers may fail to shutdown between tests on error, leaving port 8080 bound.
+# You can see what's running on port 8080 by running `lsof -i :8080`. You can
+# run `kill -9 <PID>` to terminate a process.
+#
+# USAGE:
+# ./run_conformance_tests.sh [client_version]
+#
+# client_version (optional):
+# The version of the conformance tests client to use, formatted as "vX.X.X".
+# Defaults to the latest version of the repo, which may be ahead of the
+# latest release.
+
+CLIENT_VERSION=$1
+if [ $CLIENT_VERSION ]; then
+    CLIENT_VERSION="@$CLIENT_VERSION"
+else
+    echo "Defaulting to latest client."
+    echo "Use './run_conformance_tests vX.X.X' to specify a specific release version."
+    CLIENT_VERSION="@latest"
+fi
+
+function print_header() {
+    echo
+    echo "========== $1 =========="
+}
+
+# Fail if any command fails
+set -e
+
+print_header "INSTALLING CLIENT$CLIENT_VERSION"
+echo "Note: only works with Go 1.16+ by default, see run_conformance_tests.sh for more information."
+# Go install @version only works on go 1.16+, if using a lower Go version
+# replace command with:
+# go get github.com/GoogleCloudPlatform/functions-framework-conformance/client$CLIENT_VERSION && go install github.com/GoogleCloudPlatform/functions-framework-conformance/client
+go install github.com/GoogleCloudPlatform/functions-framework-conformance/client$CLIENT_VERSION
+echo "Done installing client$CLIENT_VERSION"
+
+print_header "HTTP CONFORMANCE TESTS"
+FUNCTION_TARGET='httpFunc' FUNCTION_SIGNATURE_TYPE='http' FUNCTION_SOURCE=$(realpath tests/conformance/index.php) client -buildpacks=false -type=http -cmd='php -S localhost:8080 router.php' -start-delay 5 -validate-mapping=true
+
+print_header "DECLARATIVE HTTP CONFORMANCE TESTS"
+FUNCTION_TARGET='declarativeHttpFunc' FUNCTION_SIGNATURE_TYPE=  FUNCTION_SOURCE=$(realpath tests/conformance/index.php) client -buildpacks=false -type=http -cmd='php -S localhost:8080 router.php' -start-delay 5 -validate-mapping=true
+
+print_header "CLOUDEVENT CONFORMANCE TESTS"
+FUNCTION_TARGET='cloudEventFunc' FUNCTION_SIGNATURE_TYPE='cloudevent' FUNCTION_SOURCE=$(realpath tests/conformance/index.php) client -buildpacks=false -type=cloudevent -cmd='php -S localhost:8080 router.php' -start-delay 5 -validate-mapping=true
+
+print_header "DECLARATIVE CLOUDEVENT CONFORMANCE TESTS"
+FUNCTION_TARGET='declarativeCloudEventFunc' FUNCTION_SIGNATURE_TYPE= FUNCTION_SOURCE=$(realpath tests/conformance/index.php) client -buildpacks=false -type=cloudevent -cmd='php -S localhost:8080 router.php' -start-delay 5 -validate-mapping=true

--- a/src/CloudEventFunctionWrapper.php
+++ b/src/CloudEventFunctionWrapper.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2020 Google LLC.
  *
@@ -17,6 +18,7 @@
 
 namespace Google\CloudFunctions;
 
+use CloudEvents\V1\CloudEventInterface;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -26,6 +28,8 @@ class CloudEventFunctionWrapper extends FunctionWrapper
     private const TYPE_LEGACY = 1;
     private const TYPE_BINARY = 2;
     private const TYPE_STRUCTURED = 3;
+
+    private bool $marshalToCloudEventInterface;
 
     // These are CloudEvent context attribute names that map to binary mode
     // HTTP headers when prefixed with 'ce-'. 'datacontenttype' is notably absent
@@ -41,6 +45,12 @@ class CloudEventFunctionWrapper extends FunctionWrapper
         'subject',
         'time'
     ];
+
+    public function __construct(callable $function, bool $marshalToCloudEventInterface = false)
+    {
+        $this->marshalToCloudEventInterface = $marshalToCloudEventInterface;
+        parent::__construct($function);
+    }
 
     public function execute(ServerRequestInterface $request): ResponseInterface
     {
@@ -89,6 +99,10 @@ class CloudEventFunctionWrapper extends FunctionWrapper
                 ], 'invalid event type');
         }
 
+        if ($this->marshalToCloudEventInterface) {
+            $cloudevent = new CloudEventSdkCompliant($cloudevent);
+        }
+
         call_user_func($this->function, $cloudevent);
         return new Response();
     }
@@ -134,6 +148,6 @@ class CloudEventFunctionWrapper extends FunctionWrapper
 
     protected function getFunctionParameterClassName(): string
     {
-        return CloudEvent::class;
+        return $this->marshalToCloudEventInterface ? CloudEventInterface::class : CloudEvent::class;
     }
 }

--- a/src/CloudEventSdkCompliant.php
+++ b/src/CloudEventSdkCompliant.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\CloudFunctions;
+
+use BadMethodCallException;
+use JsonSerializable;
+use CloudEvents\V1\CloudEventInterface;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+/**
+ * @internal
+ * Wraps a Google\CloudFunctions\CloudEvent to comply with
+ * CloudEvents\V1\CloudEventInterface.
+ */
+class CloudEventSdkCompliant implements JsonSerializable, CloudEventInterface
+{
+    private $cloudevent;
+
+    public function __construct(
+        CloudEvent $cloudevent
+    ) {
+        $this->cloudevent = $cloudevent;
+    }
+
+    public function getId(): string
+    {
+        return $this->cloudevent->getId();
+    }
+    public function getSource(): string
+    {
+        return $this->cloudevent->getSource();
+    }
+    public function getSpecVersion(): string
+    {
+        return $this->cloudevent->getSpecVersion();
+    }
+    public function getType(): string
+    {
+        return $this->cloudevent->getType();
+    }
+    public function getDataContentType(): ?string
+    {
+        return $this->cloudevent->getDataContentType();
+    }
+    public function getDataSchema(): ?string
+    {
+        return $this->cloudevent->getDataSchema();
+    }
+    public function getSubject(): ?string
+    {
+        return $this->cloudevent->getSubject();
+    }
+    public function getTime(): ?DateTimeImmutable
+    {
+        return DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $this->cloudevent->getTime());
+    }
+    public function getExtension(string $attribute)
+    {
+        throw new BadMethodCallException('getExtension() is not currently supported by Functions Framework PHP');
+    }
+    public function getExtensions(): array
+    {
+        throw new BadMethodCallException('getExtensions() is not currently supported by Functions Framework PHP');
+    }
+    /**
+     * @return mixed
+     */
+    public function getData()
+    {
+        return $this->cloudevent->getData();
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->cloudevent->jsonSerialize();
+    }
+
+    public function __toString()
+    {
+        return $this->cloudevent->__toString();
+    }
+}

--- a/src/FunctionsFramework.php
+++ b/src/FunctionsFramework.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright 2021 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\CloudFunctions;
+
+use Google\CloudFunctions\Registry;
+
+class FunctionsFramework
+{
+    public static function http(string $name, callable $fn)
+    {
+        Registry::registerHttp($name, $fn);
+    }
+
+    public static function cloudEvent(string $name, callable $fn)
+    {
+        Registry::registerCloudEvent($name, $fn);
+    }
+}

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2019 Google LLC.
  *
@@ -30,19 +31,33 @@ class Invoker
     private $errorLogFunc;
 
     /**
-     * @param callable $target      The callable to be invoked
-     * @param string $signatureType The signature type of the target callable,
-     *                              either "event" or "http".
+     * @param array|string $target      The callable to be invoked
      */
-    public function __construct(callable $target, string $signatureType)
+    public function __construct($target)
     {
+        $signatureType = getenv('FUNCTION_SIGNATURE_TYPE', true) ?: 'http';
+
+        $isDeclarativeSignature = false;
+        if (is_string($target) && Registry::contains($target)) {
+            $isDeclarativeSignature = true;
+            $signatureType = Registry::getFunctionType($target);
+            $target = Registry::getFunctionHandle($target);
+        }
+
+        if (!is_callable($target)) {
+            throw new InvalidArgumentException(sprintf(
+                'Function target is not callable: "%s"',
+                $target
+            ));
+        }
+
         if ($signatureType === 'http') {
             $this->function = new HttpFunctionWrapper($target);
         } elseif (
             $signatureType === 'event'
             || $signatureType === 'cloudevent'
         ) {
-            $this->function = new CloudEventFunctionWrapper($target);
+            $this->function = new CloudEventFunctionWrapper($target, $isDeclarativeSignature);
         } else {
             throw new InvalidArgumentException(sprintf(
                 'Invalid signature type: "%s"',
@@ -51,8 +66,8 @@ class Invoker
         }
         $this->errorLogFunc = function (string $error) {
             fwrite(fopen('php://stderr', 'wb'), json_encode([
-              'message' => $error,
-              'severity' => 'error'
+                'message' => $error,
+                'severity' => 'error'
             ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
         };
     }

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Copyright 2021 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\CloudFunctions;
+
+class Registry
+{
+    public const TYPE_HTTP = "http";
+    public const TYPE_CLOUDEVENT = "cloudevent";
+
+    private static array $fnRegistry = [];
+
+    private function __construct()
+    {
+    }
+
+    public static function registerHttp(string $name, callable $fn)
+    {
+        Registry::$fnRegistry[$name] = [self::TYPE_HTTP, $fn];
+    }
+
+    public static function registerCloudEvent(string $name, callable $fn)
+    {
+        Registry::$fnRegistry[$name] = [self::TYPE_CLOUDEVENT, $fn];
+    }
+
+    public static function contains(string $name)
+    {
+        return array_key_exists($name, Registry::$fnRegistry);
+    }
+
+    public static function getFunctionType(string $name)
+    {
+        return Registry::$fnRegistry[$name][0];
+    }
+
+    public static function getFunctionHandle(string $name)
+    {
+        return Registry::$fnRegistry[$name][1];
+    }
+}

--- a/tests/CloudEventSdkCompliantTest.php
+++ b/tests/CloudEventSdkCompliantTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Copyright 2021 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\CloudFunctions\Tests;
+
+use BadMethodCallException;
+use Google\CloudFunctions\CloudEvent;
+use Google\CloudFunctions\CloudEventSdkCompliant;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+/**
+ * @group gcf-framework
+ */
+class CloudEventSdkCompliantTest extends TestCase
+{
+    private CloudEvent $cloudevent;
+
+    public function setUp(): void
+    {
+        $this->cloudevent = new CloudEvent(
+            '1413058901901494',
+            '//pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC',
+            '1.0',
+            'com.google.cloud.pubsub.topic.publish',
+            'application/json',
+            'type.googleapis.com/google.logging.v2.LogEntry',
+            'My Subject',
+            '2020-12-08T20:03:19.162Z',
+            [
+                "message" => [
+                    "data" => "SGVsbG8gdGhlcmU=",
+                    "messageId" => "1408577928008405",
+                    "publishTime" => "2020-08-06T22:31:14.536Z"
+                ],
+                "subscription" => "projects/MY-PROJECT/subscriptions/MY-SUB"
+            ]
+        );
+    }
+
+    public function testJsonSerialize(): void
+    {
+        $wrappedEvent = new CloudEventSdkCompliant($this->cloudevent);
+
+        $want = '{
+    "id": "1413058901901494",
+    "source": "\/\/pubsub.googleapis.com\/projects\/MY-PROJECT\/topics\/MY-TOPIC",
+    "specversion": "1.0",
+    "type": "com.google.cloud.pubsub.topic.publish",
+    "datacontenttype": "application\/json",
+    "dataschema": "type.googleapis.com\/google.logging.v2.LogEntry",
+    "subject": "My Subject",
+    "time": "2020-12-08T20:03:19.162Z",
+    "data": {
+        "message": {
+            "data": "SGVsbG8gdGhlcmU=",
+            "messageId": "1408577928008405",
+            "publishTime": "2020-08-06T22:31:14.536Z"
+        },
+        "subscription": "projects\\/MY-PROJECT\\/subscriptions\\/MY-SUB"
+    }
+}';
+
+        $this->assertSame($want, json_encode($wrappedEvent, JSON_PRETTY_PRINT));
+    }
+
+    public function testWrapsCloudEvent(): void
+    {
+        $wrappedEvent = new CloudEventSdkCompliant($this->cloudevent);
+
+        $this->assertSame($this->cloudevent->getId(), $wrappedEvent->getId());
+        $this->assertSame($this->cloudevent->getSource(), $wrappedEvent->getSource());
+        $this->assertSame($this->cloudevent->getType(), $wrappedEvent->getType());
+        $this->assertSame($this->cloudevent->getData(), $wrappedEvent->getData());
+        $this->assertSame($this->cloudevent->getDataContentType(), $wrappedEvent->getDataContentType());
+        $this->assertSame($this->cloudevent->getDataSchema(), $wrappedEvent->getDataSchema());
+        $this->assertSame($this->cloudevent->getSubject(), $wrappedEvent->getSubject());
+        $this->assertEquals(DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $this->cloudevent->getTime()), $wrappedEvent->getTime());
+    }
+
+    public function testUnimplementedGetExtensionThrowsError(): void
+    {
+        $wrappedEvent = new CloudEventSdkCompliant($this->cloudevent);
+        $this->expectException(BadMethodCallException::class);
+
+        $wrappedEvent->getExtension('attribute');
+    }
+
+    public function testUnimplementedGetExtensionsThrowsError(): void
+    {
+        $wrappedEvent = new CloudEventSdkCompliant($this->cloudevent);
+        $this->expectException(BadMethodCallException::class);
+
+        $wrappedEvent->getExtensions();
+    }
+}

--- a/tests/routerTest.php
+++ b/tests/routerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2019 Google LLC.
  *
@@ -19,6 +20,10 @@ namespace Google\CloudFunctions\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use Google\CloudFunctions\CloudEvent;
+use Google\CloudFunctions\FunctionsFramework;
+use Symfony\Component\Process\Process;
+use GuzzleHttp\Client;
 
 /**
  * @group gcf-framework
@@ -26,6 +31,9 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class routerTest extends TestCase
 {
+    /** @var Process */
+    private static $process;
+
     public function testInvalidFunctionTarget(): void
     {
         $this->expectException('RuntimeException');
@@ -69,6 +77,22 @@ class routerTest extends TestCase
         require 'router.php';
         $this->assertEquals($wrappers, stream_get_wrappers());
         $this->assertNotContains('gs', stream_get_wrappers());
+    }
+
+    public function testDeclarativeOverNonDeclarative(): void
+    {
+        FunctionsFramework::http('helloHttp', function (ServerRequestInterface $request) {
+            return 'Hello World!';
+        });
+
+        // index.php also has a non-declaration function named 'helloHttp'.
+        putenv('FUNCTION_SOURCE=' . __DIR__ . '/../examples/hello/index.php');
+        putenv('FUNCTION_TARGET=helloHttp');
+        putenv('FUNCTION_SIGNATURE_TYPE=cloudevent'); // ignored due to declarative signature
+        require 'router.php';
+
+        // Expect the declarative function to be called.
+        $this->expectOutputString('Hello World!');
     }
 }
 


### PR DESCRIPTION
Allow expressing the function signature type configuration through code
instead of through `FUNCTION_SIGNATURE_TYPE` env var. This means
the `FUNCTION_SIGNATURE_TYPE` var can be omitted when deploying
a function with a declarative function signature.

The new signature also changes to using the official [CloudEventInterface](https://github.com/cloudevents/sdk-php/blob/master/src/V1/CloudEventInterface.php) from the CloudEvents SDK instead of the Function Framework's custom class.

The primary difference is `$cloudevent->getTime()` returns a `DateTime` instead of a `string`. This can be converted back to a string as follows:
```php
$cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED);
```

# Define your Function
`index.php`
```php
<?php

require 'vendor/autoload.php';

use Psr\Http\Message\ServerRequestInterface;
use Google\CloudFunctions\FunctionsFramework;
use CloudEvents\V1\CloudEventInterface;
 
FunctionsFramework::http("helloHttp", func(ServerRequestInterface $request)
{
   return "Hello World from a PHP HTTP function!" . PHP_EOL;
});
 
FunctionsFramework::cloudEvent("helloCloudEvents", func(CloudEventInterface $cloudevent)
{
   // Print the whole CloudEvent
   $stdout = fopen('php://stdout', 'wb');
   fwrite($stdout, $cloudevent);
});
```

# Run your function
```bash
php -S localhost:8080 vendor/bin/router.php
```


